### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,5 @@
   "peerDependencies": {
     "nuxt": ">=3.12.0"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - "playground"
 
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  unrs-resolver: false
 
 overrides:
   "@nuxt/kit": "^4.0.0"


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`